### PR TITLE
Fix C++11 decltype example

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,7 +697,7 @@ decltype(c) d = a; // `decltype(c)` is `const int&`
 decltype(123) e = 123; // `decltype(123)` is `int`
 int&& f = 1; // `f` is declared as type `int&&`
 decltype(f) g = 1; // `decltype(f) is `int&&`
-decltype((a)) h = x; // `decltype((a))` is int&
+decltype((a)) h = g; // `decltype((a))` is int&
 ```
 ```c++
 template <typename X, typename Y>


### PR DESCRIPTION
It was using an undeclared variable on the assignment, now it uses the previous one, which I guessed was the original thought.